### PR TITLE
Allow running code coverage reports from codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
       "extensions": [
         "vscjava.vscode-java-pack",
         "ms-azuretools.vscode-docker",
-        "ms-vscode.makefile-tools"
+        "ms-vscode.makefile-tools",
+        "ritwickdey.LiveServer"
       ]
     }
   },

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'org.asciidoctor.convert' version '1.5.8'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'ro.unibuc'
@@ -52,6 +53,11 @@ test {
 	useJUnitPlatform {
 		excludeTags ("IT", "E2E")
 	}
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
 }
 
 task testIT(type: Test) {


### PR DESCRIPTION
Although code coverage reports work out of the box in IntelliJ, some students will use Github Codespaces and VSCode as the IDE.
The `vscode-java-test` extension doesn't have built-in support for coverage as outlined in https://github.com/microsoft/vscode-java-test/issues/387.

A workaround for this is to add the `jacoco` plugin in gradle. This will allow running the `jacocoTestReport` task to generate a code coverage report as html
```shell
./gradlew jacocoTestReport

output in build/reports/jacoco/test/html/index.html
```

To allow viewing the html report in Codespaces, this PR also adds [live-server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) as a default extension.