### PR TITLE
[Lab 5] Fix test task not running due to incremental build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ jacocoTestReport {
 
 task testIT(type: Test) {
 	outputs.dir snippetsDir
+	outputs.upToDateWhen { false }
 
 	useJUnitPlatform {
 		includeTags "IT"


### PR DESCRIPTION
During a lab, I tried to re-run the `testIT` task after I stopped the db container. The test was still passing when it shouldn't have. 

```
./gradlew testIT --info
> Task :testIT UP-TO-DATE
Excluding []
Excluding []
Caching disabled for task ':testIT' because:
  Build cache is disabled
Skipping task ':testIT' as it is up-to-date.
```

As part of [incremental build](https://docs.gradle.org/current/userguide/incremental_build.html), gradle will perform an up-to-date check so it won't run tasks that have no changes in them. This PR marks this task as never up-to-date so it is re-run every time.
