### PR TITLE
Disable cucumber publish message

### DIFF
--- a/src/test/resources/cucumber.properties
+++ b/src/test/resources/cucumber.properties
@@ -1,0 +1,1 @@
+cucumber.publish.quiet=true


### PR DESCRIPTION
According to:
```
┌─────────────────────────────────────────────────────────────────────────────┐
│ Share your Cucumber Report with your team at https://reports.cucumber.io    │
│ Activate publishing with one of the following:                              │
│                                                                             │
│ src/test/resources/cucumber.properties:    cucumber.publish.enabled=true    │
│ Environment variable:                      CUCUMBER_PUBLISH_ENABLED=true    │
│ JUnit:                                     @CucumberOptions(publish = true) │
│                                                                             │
│ More information at https://reports.cucumber.io/docs/cucumber-jvm           │
│                                                                             │
│ To disable this message, add cucumber.publish.quiet=true to                 │
│ src/test/resources/cucumber.properties                                      │
└─────────────────────────────────────────────────────────────────────────────┘
```