### PR TITLE
Fix codespaces + ITs + E2E tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,11 @@
 {
   "name": "production-eng-service",
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/java:dev-21-jdk-trixie",
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "21"
+      "version": "none",
+      "installGradle": "true",
+      "gradleVersion": "8.12"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
       "installGradle": "true",
       "gradleVersion": "8.12"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false // Install Docker CE instead of OSS Moby build; not part of Trixie distribution
+    }
   },
   "customizations": {
     "vscode": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
         },
         {
             "type": "java",
-            "name": "Debug Service (from Docker)",
+            "name": "Debug Service (if already running)",
             "request": "attach",
             "hostName": "localhost",
             "port": "5005"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,14 +6,13 @@
     "configurations": [
         {
             "type": "java",
-            "name": "Service",
+            "name": "Run Service",
             "request": "launch",
-            "mainClass": "ro.unibuc.hello.HelloApplication",
-            "projectName": "hello"
+            "mainClass": "ro.unibuc.hello.HelloApplication"
         },
         {
             "type": "java",
-            "name": "Debug",
+            "name": "Debug Service (from Docker)",
             "request": "attach",
             "hostName": "localhost",
             "port": "5005"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "java.server.launchMode": "Standard",
     "java.configuration.updateBuildConfiguration": "interactive",
-    "java.debug.settings.onBuildFailureProceed": true
+    "java.debug.settings.onBuildFailureProceed": true,
+    "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use official Amazon Corretto JDK 21 image as the base image
+# Use a prebuilt image providing Java 21 and a minimal OS (Alpine) the app will run on inside Docker
 FROM amazoncorretto:21-alpine-jdk
 
 # Set environment variable to configure Java to open debug port 5005

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official OpenJDK 21 image as the base image
-FROM openjdk:21-jdk
+# Use official Amazon Corretto JDK 21 image as the base image
+FROM amazoncorretto:21-alpine-jdk
 
 # Set environment variable to configure Java to open debug port 5005
 ENV JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,address=*:5005,server=y,suspend=n

--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ Follow the [./PREREQUISITES.md](./PREREQUISITES.md) instructions to configure a 
 * Make sure that the Github repository is forked under your account / Organization
 * Create a new Codespace from your forked repository
 * Wait for the Codespace to be up and running
-* Check java version
-  * ```java -version``` should return 21
-  * Validate Java version is properly configured in devcontainer.json
-  * If the correct Java version is set in devcontainer.json, but the command returns a different version:
-    * Open Command Palette (Ctrl+Shift+P) and run `Rebuild Container`
-    * Wait for the container to be rebuilt, and if the Java version is still incorrect, try a full rebuild or set it manually in the terminal:
-      * ```sdk default java 21.0.5-ms```
 * Make sure that Docker service has been started
     * ```docker ps``` should return no error
 * For running all services in docker:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ NOTE: for a live demo, please check out [this youtube video](https://youtu.be/-9
     * ```docker-compose up -d mongo```
 * Run/debug your IntelliJ run configuration
 * Open in your browser:
-    * http://localhost:8080/hello-world
-    * http://localhost:8080/info
+    * http://localhost:8080/users
 
 # Deploy and run the code locally as docker instance
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ NOTE: for a live demo, please check out [this youtube video](https://youtu.be/-9
   411475a7b596   mongo-express   "tini -- /docker-ent…"   6 seconds ago   Up 2 seconds   0.0.0.0:8090->8081/tcp     service_mongo-admin-ui_1
   ```
 * Open in your browser:
-    * http://localhost:8080/hello-world
-    * http://localhost:8080/info
+    * http://localhost:8080/users
 * You can test other API endpoints using [requests.http](requests.http)
 * You can access the MongoDB Admin UI at:
-  * http://localhost:8090 
+  * http://localhost:8090
+  * username `unibuc`, password `adobe`
+  * database `test`

--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ NOTE: for a live demo, please check out [this youtube video](https://youtu.be/-9
 * You can test other API endpoints using [requests.http](requests.http)
 * You can access the MongoDB Admin UI at:
   * http://localhost:8090
-  * username `unibuc`, password `adobe`
-  * database `test`
+  * default credentials: username `unibuc`, password `adobe`
+  * database `test` contains application entities

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
 dependencies {
 	def cucumberVersion = "7.20.1"
 	def junitVersion = "5.11.4"
-	def testcontainersVersion = "1.20.4"
+	def testcontainersVersion = "2.0.3"
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -45,7 +45,7 @@ dependencies {
 
 	// Integration tests - test containers dependencies
     testImplementation "org.testcontainers:testcontainers:$testcontainersVersion"
-    testImplementation "org.testcontainers:mongodb:$testcontainersVersion"
+    testImplementation "org.testcontainers:testcontainers-mongodb:$testcontainersVersion"
 
 	//	E2E tests
 	runtimeOnly "org.junit.vintage:junit-vintage-engine:$junitVersion"

--- a/src/test/java/ro/unibuc/hello/controller/TodoControllerIntegrationTest.java
+++ b/src/test/java/ro/unibuc/hello/controller/TodoControllerIntegrationTest.java
@@ -128,13 +128,13 @@ public class TodoControllerIntegrationTest {
         createUser("Alice", "alice@example.com");
         String todoId = createTodo("Buy milk", "alice@example.com");
 
-        mockMvc.perform(put("/todos/" + todoId + "/done")
+        mockMvc.perform(patch("/todos/" + todoId + "/done")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("true"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.done").value(true));
 
-        mockMvc.perform(put("/todos/" + todoId + "/done")
+        mockMvc.perform(patch("/todos/" + todoId + "/done")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("false"))
             .andExpect(status().isOk())

--- a/src/test/java/ro/unibuc/hello/e2e/steps/TodoSteps.java
+++ b/src/test/java/ro/unibuc/hello/e2e/steps/TodoSteps.java
@@ -112,7 +112,7 @@ public class TodoSteps {
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<Boolean> entity = new HttpEntity<>(true, headers);
 
-        restTemplate.put(BASE_URL + "/todos/" + lastCreatedTodoId + "/done", entity);
+        restTemplate.patchForObject(BASE_URL + "/todos/" + lastCreatedTodoId + "/done", entity, String.class);
     }
 
     @Then("the todo {string} for {word} is marked as done")


### PR DESCRIPTION
This PR includes fixes for the following issues:

1. Codespaces would no longer be functional when starting up due to `No space on device` errors when booting. Fixed by using lighter [JDK 21 Trixie image](https://github.com/devcontainers/images/tree/main/src/java) instead of [Universal image](https://github.com/devcontainers/images/tree/main/src/universal) (which included dependencies for multiple languages / stacks we're not using here). This also fixes a longstanding issue we've had in codespaces of how to automatically configure JDK 21, the image used comes with it automatically configured. Required explicit installation of Gradle. Also set `moby` to `false` in `docker-in-docker` feature because of the problem described in this issue https://github.com/evcc-io/evcc/issues/24265
2. Fixed run configuration in codespaces and attempted to give more explicit naming
3. `make build` command would fail due to no longer finding `openjdk:21-jdk` image, since it is deprecated: see https://hub.docker.com/_/openjdk. Fixed by using alternative `amazoncorretto:21-alpine-jdk` image instead
4. Fix test containers: running `./gradlew testIT` would fail due to the issue described in https://github.com/testcontainers/testcontainers-java/issues/11212. Fixed by using newest version of test containers (and updated artifact name for `org.testcontainers:testcontainers-mongodb`). Also fixed 1 failing IT due to put method being used instead of patch as controller describes. Now all ITs pass
5. Fixed E2E tests: similarly, replace usage of put with patch, as corresponding endpoint describes. Running `./gradlew testE2E` should have all E2E tests pass on codespaces and local (requires running service instance)
6. Updated readme examples to reference new endpoints for consistency + a few more details like mongo admin connection credentials for visibility