### PR TITLE
FEAT: add Budget API endpoints and request examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,42 @@
-# Lab1
-Modificare in README.md
+# NeverBroke Expense Tracker API
 
+## Team
+- **Team Name:** NeverBroke
+- **Members:**
+  - [Member 1 Name] - User & Category Management
+  - [Member 2 Name] - Expense Management
+  - [Member 3 Name] - Budget & Reports
 
-# 💸 NeverBroke Expense Tracker API
+## Project Description
 
-## 📖 Description
-**NeverBroke Expense Tracker API** is a Software-as-a-Service (SaaS) application that exposes RESTful APIs for managing personal expenses and budgets.  
-The system allows users to record daily expenses, organize them into categories, define monthly spending limits, and generate financial reports.
+NeverBroke Expense Tracker API is a Software-as-a-Service (SaaS) application that exposes RESTful APIs for managing personal expenses and budgets. The system allows users to record their daily expenses, organize them into categories, and define monthly spending limits in order to better control their finances.
 
-The application focuses on core business logic such as:
-- calculating monthly totals,
-- tracking expenses by category,
-- detecting when a user exceeds their defined budget.
+The application implements business logic such as calculating monthly totals, aggregating expenses by category, and detecting when a user exceeds their defined budget. It is designed as a backend-only service, intended to be consumed by external clients such as web applications, mobile apps, or API testing tools like Postman. The project focuses on clean API design, data persistence, and containerized deployment.
 
-It is implemented using **Java and Spring Boot**, uses a **SQL/NoSQL database** for permanent storage, and is packaged as a **Docker image** for easy deployment.  
-The application is designed to be used by external clients (e.g., Postman, mobile apps, or web frontends) via REST APIs. No graphical user interface is required.
-
----
-
-## ✨ Main Features
+### Key Features
 - User management  
 - Expense CRUD operations  
 - Category management  
 - Monthly budget definition  
 - Budget limit validation  
-- Monthly and per-category reports  
+- Monthly and per-category financial reports  
 
----
+### Technical Stack
+- **Backend:** Spring Boot (Java 21)
+- **Database:** MongoDB
+- **API:** RESTful
+- **Testing:** JUnit, Mockito, Cucumber
+- **Monitoring:** Prometheus, Grafana
+- **Deployment:** Docker
+
+## Contributing
+
+All team members follow trunk-based development:
+1. Create feature branch from `main`
+2. Make changes and commit with clear messages
+3. Create PR and request review
+4. Address feedback
+5. Merge after approval
 
 # Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Team
 - **Team Name:** NeverBroke
 - **Members:**
-  - [Member 1 Name] - User & Category Management
-  - [Member 2 Name] - Expense Management
-  - [Member 3 Name] - Budget & Reports
+  - Toba Catalin-Gabriel - User & Category Management
+  - Constantin Tudor-Ioan - Expense Management
+  - TBA - Budget & Reports
 
 ## Project Description
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 Modificare in README.md
 
 
+# 💸 NeverBroke Expense Tracker API
+
+## 📖 Description
+**NeverBroke Expense Tracker API** is a Software-as-a-Service (SaaS) application that exposes RESTful APIs for managing personal expenses and budgets.  
+The system allows users to record daily expenses, organize them into categories, define monthly spending limits, and generate financial reports.
+
+The application focuses on core business logic such as:
+- calculating monthly totals,
+- tracking expenses by category,
+- detecting when a user exceeds their defined budget.
+
+It is implemented using **Java and Spring Boot**, uses a **SQL/NoSQL database** for permanent storage, and is packaged as a **Docker image** for easy deployment.  
+The application is designed to be used by external clients (e.g., Postman, mobile apps, or web frontends) via REST APIs. No graphical user interface is required.
+
+---
+
+## ✨ Main Features
+- User management  
+- Expense CRUD operations  
+- Category management  
+- Monthly budget definition  
+- Budget limit validation  
+- Monthly and per-category reports  
+
+---
+
 # Prerequisites
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+# Lab1
+Modificare in README.md
+
+
 # Prerequisites
+
 
 For using Github Codespaces, no prerequisites are mandatory.
 Follow the [./PREREQUISITES.md](./PREREQUISITES.md) instructions to configure a local virtual machine with Ubuntu, Docker, IntelliJ.

--- a/requests.http
+++ b/requests.http
@@ -90,8 +90,41 @@ Content-Type: application/json
 
 
 # ==========================================
+# Category Controller Endpoints
+# ==========================================
+
+### Create a new category (run this after createUser to reuse created user id)
+# @name createCategory
+POST http://localhost:8080/api/categories
+Content-Type: application/json
+
+{
+    "name": "Work",
+    "assignedUserId": "{{createUser.response.body.id}}"
+}
+
+### Get all categories
+GET http://localhost:8080/api/categories
+
+### Get category by ID (uses ID from createCategory response)
+GET http://localhost:8080/api/categories/{{createCategory.response.body.id}}
+
+### Try duplicate category name (should fail with validation/error)
+POST http://localhost:8080/api/categories
+Content-Type: application/json
+
+{
+    "name": "Work",
+    "assignedUserId": "{{createUser.response.body.id}}"
+}
+
+
+# ==========================================
 # Cleanup (run these last)
 # ==========================================
+
+### Delete category
+DELETE http://localhost:8080/api/categories/{{createCategory.response.body.id}}
 
 ### Delete todo
 DELETE http://localhost:8080/api/todos/{{createTodo.response.body.id}}

--- a/requests.http
+++ b/requests.http
@@ -120,8 +120,48 @@ Content-Type: application/json
 
 
 # ==========================================
+# Budget Controller Endpoints
+# ==========================================
+
+### Create a new budget (run this after createUser to reuse created user id)
+# @name createBudget
+POST http://localhost:8080/api/budgets
+Content-Type: application/json
+
+{
+    "assignedUserId": "{{createUser.response.body.id}}",
+    "month": "2026-03",
+    "amount": 1500,
+    "currency": "EUR"
+}
+
+### Get all budgets
+GET http://localhost:8080/api/budgets
+
+### Get budget by ID (uses ID from createBudget response)
+GET http://localhost:8080/api/budgets/{{createBudget.response.body.id}}
+
+### Get budgets by user ID
+GET http://localhost:8080/api/budgets/user/{{createUser.response.body.id}}
+
+### Update budget
+PUT http://localhost:8080/api/budgets/{{createBudget.response.body.id}}
+Content-Type: application/json
+
+{
+    "assignedUserId": "{{createUser.response.body.id}}",
+    "month": "2026-04",
+    "amount": 1800,
+    "currency": "EUR"
+}
+
+
+# ==========================================
 # Cleanup (run these last)
 # ==========================================
+
+### Delete budget
+DELETE http://localhost:8080/api/budgets/{{createBudget.response.body.id}}
 
 ### Delete category
 DELETE http://localhost:8080/api/categories/{{createCategory.response.body.id}}

--- a/src/main/java/ro/unibuc/prodeng/controller/BudgetController.java
+++ b/src/main/java/ro/unibuc/prodeng/controller/BudgetController.java
@@ -1,0 +1,53 @@
+package ro.unibuc.prodeng.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.annotation.*;
+
+import ro.unibuc.prodeng.request.CreateBudgetRequest;
+import ro.unibuc.prodeng.response.BudgetResponse;
+import ro.unibuc.prodeng.service.BudgetService;
+
+@RestController
+@RequestMapping("api/budgets")
+public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    public BudgetController(BudgetService budgetService) {
+        this.budgetService = budgetService;
+    }
+
+    @GetMapping
+    public List<BudgetResponse> getAllBudgets() {
+        return budgetService.getAllBudgets();
+    }
+
+    @GetMapping("/{id}")
+    public BudgetResponse getBudgetById(@PathVariable @NonNull String id) {
+        return budgetService.getBudgetById(id);
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<BudgetResponse> getBudgetsByUserId(@PathVariable @NonNull String userId) {
+        return budgetService.getBudgetsByUserId(userId);
+    }
+
+    @PostMapping
+    public BudgetResponse createBudget(@RequestBody CreateBudgetRequest request) {
+        return budgetService.createBudget(request);
+    }
+
+    @PutMapping("/{id}")
+    public BudgetResponse updateBudget(@PathVariable @NonNull String id, @RequestBody CreateBudgetRequest request) {
+        return budgetService.updateBudget(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBudget(@PathVariable @NonNull String id) {
+        budgetService.deleteBudget(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ro/unibuc/prodeng/controller/CategoryController.java
+++ b/src/main/java/ro/unibuc/prodeng/controller/CategoryController.java
@@ -1,0 +1,43 @@
+package ro.unibuc.prodeng.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.annotation.*;
+
+import ro.unibuc.prodeng.request.CreateCategoryRequest;
+import ro.unibuc.prodeng.response.CategoryResponse;
+import ro.unibuc.prodeng.service.CategoryService;
+
+@RestController
+@RequestMapping("api/categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping
+    public List<CategoryResponse> getAllCategories() {
+        return categoryService.getAllCategories();
+    }
+
+    @GetMapping("/{id}")
+    public CategoryResponse getCategoryById(@PathVariable @NonNull String id) {
+        return categoryService.getCategoryById(id);
+    }
+
+    @PostMapping
+    public CategoryResponse createCategory(@RequestBody CreateCategoryRequest request) {
+        return categoryService.createCategory(request);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable @NonNull String id) {
+        categoryService.deleteCategory(id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/ro/unibuc/prodeng/model/BudgetEntity.java
+++ b/src/main/java/ro/unibuc/prodeng/model/BudgetEntity.java
@@ -1,0 +1,14 @@
+package ro.unibuc.prodeng.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "budget")
+public record BudgetEntity(
+    @Id
+    String id,
+    String assignedUserId,
+    String month,
+    double amount,
+    String currency
+) {}

--- a/src/main/java/ro/unibuc/prodeng/model/CategoryEntity.java
+++ b/src/main/java/ro/unibuc/prodeng/model/CategoryEntity.java
@@ -1,0 +1,13 @@
+package ro.unibuc.prodeng.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "category")
+public record CategoryEntity (
+    
+    @Id
+    String id,
+    String name,
+    String assignedUserId
+) {}

--- a/src/main/java/ro/unibuc/prodeng/repository/BudgetRepository.java
+++ b/src/main/java/ro/unibuc/prodeng/repository/BudgetRepository.java
@@ -1,0 +1,10 @@
+package ro.unibuc.prodeng.repository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import ro.unibuc.prodeng.model.BudgetEntity;
+
+public interface BudgetRepository extends MongoRepository<BudgetEntity, String> {
+    List<BudgetEntity> findByAssignedUserId(String assignedUserId);
+}

--- a/src/main/java/ro/unibuc/prodeng/repository/CategoryRepository.java
+++ b/src/main/java/ro/unibuc/prodeng/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package ro.unibuc.prodeng.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import ro.unibuc.prodeng.model.CategoryEntity;
+
+public interface CategoryRepository extends MongoRepository<CategoryEntity, String> {
+	Optional<CategoryEntity> findByName(String name);
+	Optional<CategoryEntity> findByAssignedUserId(String assignedUserId);
+}

--- a/src/main/java/ro/unibuc/prodeng/request/CreateBudgetRequest.java
+++ b/src/main/java/ro/unibuc/prodeng/request/CreateBudgetRequest.java
@@ -1,0 +1,19 @@
+package ro.unibuc.prodeng.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateBudgetRequest(  
+
+    @NotBlank(message = "User ID is required")
+    String assignedUserId,
+
+    @NotBlank(message = "Month is required")
+    String month,
+
+    @NotBlank(message = "Amount is required")
+    double amount,
+
+    @NotBlank(message = "Currency is required")
+    String currency
+
+) {}

--- a/src/main/java/ro/unibuc/prodeng/request/CreateCategoryRequest.java
+++ b/src/main/java/ro/unibuc/prodeng/request/CreateCategoryRequest.java
@@ -1,0 +1,12 @@
+package ro.unibuc.prodeng.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCategoryRequest (
+    
+    @NotBlank(message = "Name is required")
+    String name,
+
+    @NotBlank(message = "Assigned user ID is required")
+    String assignedUserId
+) {}

--- a/src/main/java/ro/unibuc/prodeng/response/BudgetResponse.java
+++ b/src/main/java/ro/unibuc/prodeng/response/BudgetResponse.java
@@ -1,0 +1,10 @@
+package ro.unibuc.prodeng.response;
+
+public record BudgetResponse (
+    String id,
+    String assignedUserId,
+    String month,
+    double amount,
+    String currency
+
+) {}

--- a/src/main/java/ro/unibuc/prodeng/response/CategoryResponse.java
+++ b/src/main/java/ro/unibuc/prodeng/response/CategoryResponse.java
@@ -1,0 +1,7 @@
+package ro.unibuc.prodeng.response;
+
+public record CategoryResponse (
+    String id,
+    String name,
+    String assignedUserId
+) {}

--- a/src/main/java/ro/unibuc/prodeng/service/BudgetService.java
+++ b/src/main/java/ro/unibuc/prodeng/service/BudgetService.java
@@ -1,0 +1,83 @@
+package ro.unibuc.prodeng.service;
+
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+
+import ro.unibuc.prodeng.model.BudgetEntity;
+import ro.unibuc.prodeng.repository.BudgetRepository;
+import ro.unibuc.prodeng.request.CreateBudgetRequest;
+import ro.unibuc.prodeng.response.BudgetResponse;
+
+@Service
+public class BudgetService {
+
+    private final BudgetRepository budgetRepository;
+
+    public BudgetService(BudgetRepository budgetRepository) {
+        this.budgetRepository = budgetRepository;
+    }
+
+    public List<BudgetResponse> getAllBudgets() {
+        return budgetRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public BudgetResponse getBudgetById(@NonNull String id) {
+        var budget = budgetRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Budget not found with id: " + id));
+        return toResponse(budget);
+    }
+
+    public List<BudgetResponse> getBudgetsByUserId(@NonNull String userId) {
+        return budgetRepository.findByAssignedUserId(userId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public BudgetResponse createBudget(CreateBudgetRequest request) {
+        BudgetEntity budget = new BudgetEntity(
+                null,
+                request.assignedUserId(),
+                request.month(),
+                request.amount(),
+                request.currency()
+        );
+        BudgetEntity saved = budgetRepository.save(budget);
+        return toResponse(saved);
+    }
+
+    public BudgetResponse updateBudget(@NonNull String id, CreateBudgetRequest request) {
+        var existing = budgetRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Budget not found with id: " + id));
+        var updated = new BudgetEntity(
+                existing.id(),
+                request.assignedUserId(),
+                request.month(),
+                request.amount(),
+                request.currency()
+        );
+        var saved = budgetRepository.save(updated);
+        return toResponse(saved);
+    }
+
+    public void deleteBudget(@NonNull String id) {
+        if (!budgetRepository.existsById(id)) {
+            throw new RuntimeException("Budget not found with id: " + id);
+        }
+        budgetRepository.deleteById(id);
+    }
+
+    private BudgetResponse toResponse(BudgetEntity budget) {
+        return new BudgetResponse(
+                budget.id(),
+                budget.assignedUserId(),
+                budget.month(),
+                budget.amount(),
+                budget.currency()
+        );
+    }
+
+}

--- a/src/main/java/ro/unibuc/prodeng/service/CategoryService.java
+++ b/src/main/java/ro/unibuc/prodeng/service/CategoryService.java
@@ -1,0 +1,84 @@
+package ro.unibuc.prodeng.service;
+
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+
+import ro.unibuc.prodeng.model.CategoryEntity;
+import ro.unibuc.prodeng.repository.CategoryRepository;
+import ro.unibuc.prodeng.request.CreateCategoryRequest;
+import ro.unibuc.prodeng.response.CategoryResponse;
+
+@Service
+public class CategoryService {
+    
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<CategoryResponse> getAllCategories() {
+        return categoryRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public CategoryResponse getCategoryById(@NonNull String id) {
+        var category = categoryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Category not found with id: " + id));
+        return toResponse(category);
+    }
+
+    public CategoryResponse createCategory(CreateCategoryRequest request) {
+        if (categoryRepository.findByName(request.name()).isPresent()) {
+            throw new IllegalArgumentException("Category name already exists: " + request.name());
+        }
+        CategoryEntity category = new CategoryEntity(
+                null,
+                request.name(),
+                request.assignedUserId()
+        );
+        CategoryEntity saved = categoryRepository.save(category);
+        return toResponse(saved);
+    }
+
+    public CategoryResponse changeName(@NonNull String id, String newName) {
+        var existing = categoryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Category not found with id: " + id));
+        var updated = new CategoryEntity(existing.id(), newName, existing.assignedUserId());
+        var saved = categoryRepository.save(updated);
+        return toResponse(saved);
+    }
+
+    public void deleteCategory(@NonNull String id) {
+        if (!categoryRepository.existsById(id)) {
+            throw new RuntimeException("Category not found with id: " + id);
+        }
+        categoryRepository.deleteById(id);
+    }
+
+    public CategoryResponse assign(@NonNull String id, String userId) {
+        var existing = categoryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Category not found with id: " + id));
+        var updated = new CategoryEntity(existing.id(), existing.name(), userId);
+        var saved = categoryRepository.save(updated);
+        return toResponse(saved);
+    }
+
+    public CategoryResponse getCategoryByAssignedUserId(@NonNull String userId) {
+        var category = categoryRepository.findByAssignedUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Category not found for user id: " + userId));
+        return toResponse(category);
+    }
+
+    private CategoryResponse toResponse(CategoryEntity category) {
+        return new CategoryResponse(
+                category.id(),
+                category.name(),
+                category.assignedUserId()
+        );
+    }
+
+}


### PR DESCRIPTION
Changes: Added Budget support end-to-end: BudgetEntity, BudgetRepository, CreateBudgetRequest, BudgetResponse, BudgetService, and BudgetController (GET all, GET by id, GET by user id, POST, PUT, DELETE). Also updated requests.http with budget create/list/get-by-id/get-by-user/update/delete examples.

Special considerations: A user can have multiple budgets, so querying by assigned user id returns a list. Not-found handling currently uses runtime exceptions.